### PR TITLE
Added semicolon to the end of structs and enums

### DIFF
--- a/Dumper/wrappers.cpp
+++ b/Dumper/wrappers.cpp
@@ -595,7 +595,7 @@ void UE_UPackage::SaveStruct(std::vector<Struct>& arr, File file)
 			}
 		}
 		
-		fmt::print(file, "\n}}\n\n");
+		fmt::print(file, "\n}};\n\n");
 	}
 }
 
@@ -628,7 +628,7 @@ bool UE_UPackage::Save(const fs::path& dir)
 				{
 					fmt::print(file, "\n\t{},", m);
 				}
-				fmt::print(file, "\n}}\n\n");
+				fmt::print(file, "\n}};\n\n");
 			}
 		}
 


### PR DESCRIPTION
This allows generated structs and enums to be valid in C++ projects.