### PR TITLE
Add UFunction information dump

### DIFF
--- a/Dumper/engine.cpp
+++ b/Dumper/engine.cpp
@@ -45,6 +45,11 @@ struct DeadByDaylight {
 	} UEnum;
 
 	struct {
+		uint16_t Flags = 0xB8;
+		uint16_t FuncPtr = 0xB8+0x28; // ue3-ue4, always +0x28 from flags location.
+	} UFunction;
+
+	struct {
 		uint16_t Class = 0x8;
 		uint16_t Next = 0x20;
 		uint16_t Name = 0x28;
@@ -151,6 +156,11 @@ struct RogueCompany {
 	struct {
 		uint16_t Names = 0x40;
 	} UEnum;
+
+	struct {
+		uint16_t Flags = 0xB8;
+		uint16_t FuncPtr = 0xB8 + 0x28;
+	} UFunction;
 
 	struct {
 		uint16_t Class = 0x8;

--- a/Dumper/engine.h
+++ b/Dumper/engine.h
@@ -41,6 +41,11 @@ struct Offsets {
 	} UEnum;
 
 	struct {
+		uint16_t Flags = 0;
+		uint16_t FuncPtr = 0;
+	} UFunction;
+
+	struct {
 		uint16_t Class = 0;
 		uint16_t Next = 0;
 		uint16_t Name = 0;

--- a/Dumper/main.cpp
+++ b/Dumper/main.cpp
@@ -28,6 +28,7 @@ protected:
     bool Full = true;
     bool Wait = false;
     fs::path Directory;
+    size_t ModuleBase = 0;
 private:
     Dumper() {};
     static bool FindObjObjects(byte* start, byte* end) 
@@ -110,6 +111,8 @@ public:
             auto sections = GetExSections(image.data());
             if (!sections.size()) { return INVALID_IMAGE; }
 
+            ModuleBase = (size_t)base;
+
             bool err = false;
             for (auto& section : sections) { if (FindObjObjects(section.first, section.second)) { err = true; break; }; }
             if (!err) { return OBJECTS_NOT_FOUND; };
@@ -188,7 +191,7 @@ public:
                 {
                     fmt::print("\rProcessing: {}/{}", i++, packages.size());
 
-                    package.Process();
+                    package.Process(ModuleBase);
                     if (package.Save(path)) { saved++; }
                     else { unsaved += (package.GetObject().GetName() + ", "); };
                 }

--- a/Dumper/wrappers.h
+++ b/Dumper/wrappers.h
@@ -104,11 +104,51 @@ public:
 	static UE_UClass StaticClass();
 };
 
+enum class UEFunctionFlags : uint32_t
+{
+	Final = 0x00000001,
+	RequiredAPI = 0x00000002,
+	BlueprintAuthorityOnly = 0x00000004,
+	BlueprintCosmetic = 0x00000008,
+	Net = 0x00000040,
+	NetReliable = 0x00000080,
+	NetRequest = 0x00000100,
+	Exec = 0x00000200,
+	Native = 0x00000400,
+	Event = 0x00000800,
+	NetResponse = 0x00001000,
+	Static = 0x00002000,
+	NetMulticast = 0x00004000,
+	MulticastDelegate = 0x00010000,
+	Public = 0x00020000,
+	Private = 0x00040000,
+	Protected = 0x00080000,
+	Delegate = 0x00100000,
+	NetServer = 0x00200000,
+	HasOutParms = 0x00400000,
+	HasDefaults = 0x00800000,
+	NetClient = 0x01000000,
+	DLLImport = 0x02000000,
+	BlueprintCallable = 0x04000000,
+	BlueprintEvent = 0x08000000,
+	BlueprintPure = 0x10000000,
+	Const = 0x40000000,
+	NetValidate = 0x80000000
+};
+
+inline bool operator&(UEFunctionFlags lhs, UEFunctionFlags rhs)
+{
+	return (static_cast<std::underlying_type_t<UEFunctionFlags>>(lhs) & static_cast<std::underlying_type_t<UEFunctionFlags>>(rhs)) == static_cast<std::underlying_type_t<UEFunctionFlags>>(rhs);
+}
+
 class UE_UFunction : public UE_UStruct
 {
 public:
 	using UE_UStruct::UE_UStruct;
 	static UE_UClass StaticClass();
+	UEFunctionFlags GetFunctionFlags() const;
+	size_t GetFunctionPtr() const;
+	std::string GetFlagsStringified(UEFunctionFlags flags) const;
 };
 
 class UE_UScriptStruct : public UE_UStruct
@@ -315,6 +355,9 @@ private:
 		std::string FullName;
 		std::string CppName;
 		std::string Params;
+		std::string FlagsString;
+		uint32_t Flags;
+		size_t FuncPtr;
 	};
 	struct Struct
 	{
@@ -336,15 +379,16 @@ private:
 	std::vector<Struct> Classes;
 	std::vector<Struct> Structures;
 	std::vector<Enum> Enums;
+	size_t ModuleBase;
 private:
 	static void GenerateBitPadding(std::vector<Member>& members, int32_t offset, int16_t bitOffset, int16_t size);
 	static void GeneratePadding(std::vector<Member>& members, int32_t& minOffset, int32_t& bitOffset, int32_t maxOffset);
 	static void GenerateStruct(UE_UStruct object, std::vector<Struct>& arr);
 	static void GenerateEnum(UE_UEnum object, std::vector<Enum>& arr);
-	static void SaveStruct(std::vector<Struct>& arr, File file);
+	void SaveStruct(std::vector<Struct>& arr, File file);
 public:
 	UE_UPackage(std::pair<byte* const, std::vector<UE_UObject>>& package) : Package(&package) {};
-	void Process();
+	void Process(size_t ModuleBase);
 	bool Save(const fs::path& dir);
 	UE_UObject GetObject() const;
 };


### PR DESCRIPTION
Flags and relative address of functions (when native) are very useful if you would like to reverse engineer how they are implemented.

Unimplemented, but json/txt might be better output format for that data for use in an IDAPython script, maybe preferable to comments if you're analyzing a huge amount of functions.... just a thought.

Needed to pass module base to the package dumper to avoid multiple fetches. Needed to make SaveStruct non-static due to that. Not sure why those are static - if it's perf to avoid an indirect call there, probably doesn't save much on perf, but alternative would be to keep a static for the modulebase too. 

Next: Integrate Kismet VM bytecode dump & disassembly engine? Can resolve things like the "unknown" padding below by walking the bytecode/native disassembly and looking at self-references, then can define members based on which blueprint/script it occurred in, or which native function the reference occurred in. 
```c
// Class DeadByDaylight.SkillCheck
// Size: 0x300 (Inherited: 0x210)
struct USkillCheck : USceneComponent {
	char UnknownData_210[0x40]; // 0x210(0x40) 
	struct ADBDPlayer* _owner; // 0x250(0x08)
	struct UChargeableInteractionDefinition* _currentInteraction; // 0x258(0x08)
	char UnknownData_260[0xa0]; // 0x260(0xa0)      <------------------------
};
```
After walking references, would turn into something like:
```c
// Class DeadByDaylight.SkillCheck
// Size: 0x300 (Inherited: 0x210)
struct USkillCheck : USceneComponent {
	char UnknownData_210[0x40]; // 0x210(0x40)
	struct ADBDPlayer* _owner; // 0x250(0x08)
	struct UChargeableInteractionDefinition* _currentInteraction; // 0x258(0x08)
	uint32_t Referenced_Field0; // 0x260(0x04) READ by: OnSkillCheckInput // WRITTEN by: ActivateSkillCheck, DeactivateSkillCheck
	char UnknownData_260[0x98]; // 0x264(0x98)
};
```

Also: Maybe need cleaner way to define fields that are almost always relative from another field, like UFunction.FuncPtr. Up to you.