### PR TITLE
Fixed datatype causing issues on other compilers

### DIFF
--- a/Dumper/utils.cpp
+++ b/Dumper/utils.cpp
@@ -18,7 +18,7 @@ uint8* FindSignature(void* start, void* end, const char* sig, uint32 size) {
       return it;
     };
   }
-  return 0;
+  return nullptr;
 }
 
 void* FindPointer(void* start, void* end, const char* sig, uint32 size, int32 addition) {


### PR DESCRIPTION
Seems to be fine to return as 0 on visual studio but CMake will not make it work.